### PR TITLE
Add CLAUDE.md with project instructions and Clojure tooling setup

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+install_clojure() {
+  if command -v clojure &>/dev/null; then
+    return 0
+  fi
+  curl -sL -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh
+  chmod +x linux-install.sh
+  sudo bash linux-install.sh
+  rm -f linux-install.sh
+}
+
+install_babashka() {
+  if command -v bb &>/dev/null; then
+    return 0
+  fi
+  curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
+  chmod +x install
+  sudo ./install
+  rm -f install
+}
+
+install_bbin() {
+  if command -v bbin &>/dev/null; then
+    return 0
+  fi
+  mkdir -p ~/.local/bin
+  curl -sL -o ~/.local/bin/bbin https://raw.githubusercontent.com/babashka/bbin/main/bbin
+  chmod +x ~/.local/bin/bbin
+  export PATH="$HOME/.local/bin:$PATH"
+  echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+}
+
+setup_bbin_deps() {
+  local clj_tools_dir="$HOME/.deps.clj"
+  local latest_jar=$(find "$clj_tools_dir" -name "clojure-tools-*.jar" 2>/dev/null | head -1)
+  if [ -n "$latest_jar" ]; then
+    return 0
+  fi
+  local version="1.12.4.1618"
+  local tools_dir="$clj_tools_dir/$version/ClojureTools"
+  mkdir -p "$tools_dir"
+  curl -sL -o "$tools_dir/clojure-tools.zip" \
+    "https://github.com/clojure/brew-install/releases/download/$version/clojure-tools.zip"
+  unzip -o -q "$tools_dir/clojure-tools.zip" -d "$tools_dir"
+  mv "$tools_dir/ClojureTools/"* "$tools_dir/" 2>/dev/null || true
+}
+
+install_clojure_mcp_light() {
+  if command -v clj-paren-repair-claude-hook &>/dev/null; then
+    return 0
+  fi
+  local repo="https://github.com/bhauman/clojure-mcp-light.git"
+  local tag="v0.2.2"
+  bbin install "$repo" --tag "$tag"
+  bbin install "$repo" --tag "$tag" --as clj-nrepl-eval --main-opts '["-m" "clojure-mcp-light.nrepl-eval"]'
+  bbin install "$repo" --tag "$tag" --as clj-paren-repair --main-opts '["-m" "clojure-mcp-light.paren-repair"]'
+}
+
+warm_clojure_deps() {
+  cd "$CLAUDE_PROJECT_DIR"
+  clojure -P 2>/dev/null || true
+  clojure -P -X:test 2>/dev/null || true
+}
+
+install_clojure
+install_babashka
+install_bbin
+setup_bbin_deps
+install_clojure_mcp_light
+warm_clojure_deps

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,6 +5,8 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+echo '{"async": true, "asyncTimeout": 300000}'
+
 install_clojure() {
   if command -v clojure &>/dev/null; then
     return 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# Illumina Run Simulator
+
+Clojure project that simulates Illumina DNA sequencer output directories for testing.
+
+## Build & Test
+
+- Run tests: `clojure -X:test`
+- Build uberjar: `clojure -T:build uber`
+- Run: `java -jar target/illumina-run-simulator-0.2.3-standalone.jar --config config.edn`
+
+## Clojure REPL Evaluation
+
+The command `clj-nrepl-eval` is installed on your path for evaluating Clojure code via nREPL.
+
+**Discover nREPL servers:**
+
+`clj-nrepl-eval --discover-ports`
+
+**Evaluate code:**
+
+`clj-nrepl-eval -p <port> "<clojure-code>"`
+
+With timeout (milliseconds)
+
+`clj-nrepl-eval -p <port> --timeout 5000 "<clojure-code>"`
+
+The REPL session persists between evaluations - namespaces and state are maintained.
+Always use `:reload` when requiring namespaces to pick up changes.
+
+## Clojure Parenthesis Repair
+
+The command `clj-paren-repair` is installed on your path.
+
+Examples:
+`clj-paren-repair <files>`
+`clj-paren-repair path/to/file1.clj path/to/file2.clj`
+
+**IMPORTANT:** Do NOT try to manually repair parenthesis errors.
+If you encounter unbalanced delimiters, run `clj-paren-repair` on the file
+instead of attempting to fix them yourself. If the tool doesn't work,
+report to the user that they need to fix the delimiter error manually.


### PR DESCRIPTION
Includes build/test commands, clj-nrepl-eval usage, and clj-paren-repair
instructions for LLM-assisted Clojure development.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dwon1Ynmuvo1SsDmEQ7SLk