### PR TITLE
Refactor generators for idiomatic test.check usage

### DIFF
--- a/src/run_simulator/core.clj
+++ b/src/run_simulator/core.clj
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [clojure.tools.cli :refer [parse-opts]]
             [clojure.spec.alpha :as spec]
-            [clojure.spec.gen.alpha :as spec-gen]
+            [clojure.spec.gen.alpha :as gen]
             [run-simulator.cli :as cli]
             [run-simulator.util :as util]
             [run-simulator.generators :as generators]
@@ -23,9 +23,9 @@
                :nextseq six-digit-date
                :i100 eight-digit-date)
         run-id (case instrument-type
-                 :miseq (first (spec-gen/sample generators/miseq-flowcell-id 1))
-                 :nextseq (first (spec-gen/sample generators/nextseq-flowcell-id 1))
-                 :i100 (first (spec-gen/sample generators/i100-flowcell-id 1)))]
+                 :miseq (gen/generate generators/miseq-flowcell-id)
+                 :nextseq (gen/generate generators/nextseq-flowcell-id)
+                 :i100 (gen/generate generators/i100-flowcell-id))]
     (str/join "_" [date
                    instrument-id
                    run-num
@@ -35,7 +35,7 @@
 (defn generate-sample-id
   ""
   [plate-num index]
-  (str/join "-" [(first (spec-gen/sample generators/container-id 1))
+  (str/join "-" [(gen/generate generators/container-id)
                  plate-num
                  (:Index_Set index)
                  (:Index_Plate_Well index)]))
@@ -84,11 +84,11 @@
   ([output-dir-strucutre-type db]
    (case output-dir-strucutre-type
      :old "Data/Intensities/BaseCalls"
-     :new (str (io/file "Alignment_1" (str (str/replace (str (:current-date @db)) "-" "") "_" (first (spec-gen/sample generators/six-digit-timestamp 1))) "Fastq"))))
+     :new (str (io/file "Alignment_1" (str (str/replace (str (:current-date @db)) "-" "") "_" (gen/generate generators/six-digit-timestamp)) "Fastq"))))
   ([output-dir-strucutre-type demultiplexing-num db]
    (case output-dir-strucutre-type
      :old "Data/Intensities/BaseCalls"
-     :new (str (io/file (str "Alignment_" demultiplexing-num) (str (str/replace (str (:current-date @db)) "-" "") "_" (first (spec-gen/sample generators/six-digit-timestamp 1))) "Fastq")))))
+     :new (str (io/file (str "Alignment_" demultiplexing-num) (str (str/replace (str (:current-date @db)) "-" "") "_" (gen/generate generators/six-digit-timestamp)) "Fastq")))))
 
 
 (defn simulate-run!

--- a/src/run_simulator/generators.clj
+++ b/src/run_simulator/generators.clj
@@ -1,15 +1,16 @@
 (ns run-simulator.generators
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
-            [clojure.spec.test.alpha :as spec-test]))
+            [clojure.string :as str]))
 
 
 (def char-uppercase-alphanumeric
-  (gen/such-that #(or (Character/isUpperCase %) (Character/isDigit %)) (gen/char-alphanumeric)))
+  (gen/elements (into (mapv char (range 65 91))
+                      (mapv char (range 48 58)))))
 
 
 (def char-uppercase-alphabetic
-  (gen/such-that #(Character/isUpperCase %) (gen/char-alphanumeric)))
+  (gen/elements (mapv char (range 65 91))))
 
 
 (s/def ::i100-flowcell-num (s/int-in 2200000 2300000))
@@ -34,8 +35,7 @@
 
 
 (def zero-padded-month
-  (let [pad-zero #(if (> % 9) (str %) (str 0 %))]
-    (gen/fmap pad-zero (gen/choose 1 12))))
+  (make-zero-padded-num 1 12 2))
 
 (def two-digit-year
   (gen/fmap str (gen/choose 16 32)))
@@ -57,22 +57,25 @@
                   "10" 31
                   "11" 30
                   "12" 31}]
-    (gen/bind zero-padded-month (fn [month] (gen/fmap #(str month %) (make-zero-padded-num 1 (num-days month) 2))))))
+    (gen/bind zero-padded-month
+              (fn [month]
+                (gen/fmap #(str month %) (make-zero-padded-num 1 (num-days month) 2))))))
 
 
 (def six-digit-date
-  (gen/bind two-digit-year
-                 (fn [year] (gen/fmap #(str year %) four-digit-date))))
+  (gen/fmap (fn [[year date]] (str year date))
+            (gen/tuple two-digit-year four-digit-date)))
 
 (def eight-digit-date
-  (gen/bind four-digit-year
-                 (fn [year] (gen/fmap #(str year %) four-digit-date))))
+  (gen/fmap (fn [[year date]] (str year date))
+            (gen/tuple four-digit-year four-digit-date)))
 
 
 (def six-digit-timestamp
-  (-> (make-zero-padded-num 0 24 2)
-      (gen/bind (fn [x] (gen/fmap #(str x %) (make-zero-padded-num 0 60 2))))
-      (gen/bind (fn [x] (gen/fmap #(str x %) (make-zero-padded-num 0 60 2))))))
+  (gen/fmap (fn [[h m s]] (str h m s))
+            (gen/tuple (make-zero-padded-num 0 23 2)
+                       (make-zero-padded-num 0 59 2)
+                       (make-zero-padded-num 0 59 2))))
 
 
 (def miseq-instrument-id
@@ -87,53 +90,67 @@
 
 
 (def miseq-run-id
-  (-> six-digit-date
-      (gen/bind (fn [x] (gen/fmap #(str x "_" %) miseq-instrument-id)))
-      (gen/bind (fn [x] (gen/fmap #(str x "_" %) (make-zero-padded-num 1 9999 4))))
-      (gen/bind (fn [x] (gen/fmap #(str x "_" %) miseq-flowcell-id)))))
+  (gen/fmap (fn [[date inst run fc]]
+              (str/join "_" [date inst run fc]))
+            (gen/tuple six-digit-date
+                       miseq-instrument-id
+                       (make-zero-padded-num 1 9999 4)
+                       miseq-flowcell-id)))
 
 
 (def miseq-run-id-regex #"^[0-9]{6}_M[0-9]{5}_[0-9]{4}_000000000-[A-Z0-9]{5}$")
 
 
-(s/def ::miseq-run-id (s/and string? #(re-matches miseq-run-id-regex %)))
+(s/def ::miseq-run-id
+  (s/with-gen
+    (s/and string? #(re-matches miseq-run-id-regex %))
+    (fn [] miseq-run-id)))
 
 
 (def nextseq-run-id
-  (-> six-digit-date
-      (gen/bind (fn [x] (gen/fmap #(str x "_" %) nextseq-instrument-id)))
-      (gen/bind (fn [x] (gen/fmap #(str x "_" (str %)) (gen/choose 1 500))))
-      (gen/bind (fn [x] (gen/fmap #(str x "_" %) nextseq-flowcell-id)))))
+  (gen/fmap (fn [[date inst run fc]]
+              (str/join "_" [date inst run fc]))
+            (gen/tuple six-digit-date
+                       nextseq-instrument-id
+                       (gen/fmap str (gen/choose 1 500))
+                       nextseq-flowcell-id)))
 
 
 (def nextseq-run-id-regex #"^[0-9]{6}_VH[0-9]{5}_[0-9]+_[A-Z0-9]{9}$")
 
 
-(s/def ::nextseq-run-id (s/and string? #(re-matches nextseq-run-id-regex %)))
+(s/def ::nextseq-run-id
+  (s/with-gen
+    (s/and string? #(re-matches nextseq-run-id-regex %))
+    (fn [] nextseq-run-id)))
 
 (def i100-run-id
-  (-> eight-digit-date
-      (gen/bind (fn [x] (gen/fmap #(str x "_" %) i100-instrument-id)))
-      (gen/bind (fn [x] (gen/fmap #(str x "_" (str %)) (gen/choose 1 500))))
-      (gen/bind (fn [x] (gen/fmap #(str x "_" %) i100-flowcell-id)))))
-
+  (gen/fmap (fn [[date inst run fc]]
+              (str/join "_" [date inst run fc]))
+            (gen/tuple eight-digit-date
+                       i100-instrument-id
+                       (make-zero-padded-num 1 500 4)
+                       i100-flowcell-id)))
 
 
 (def i100-run-id-regex #"^[0-9]{8}_SH[0-9]{5}_[0-9]{4}_ASC[0-9]{7}-SC3$")
 
-(s/def ::i100-run-id (s/and string? #(re-matches i100-run-id-regex %)))
+(s/def ::i100-run-id
+  (s/with-gen
+    (s/and string? #(re-matches i100-run-id-regex %))
+    (fn [] i100-run-id)))
 
 (def library-id
-  (-> (gen/return "BC")
-      (gen/bind (fn [x] (gen/fmap #(str x %) two-digit-year)))
-      (gen/bind (fn [x] (gen/fmap #(str x %) char-uppercase-alphabetic)))
-      (gen/bind (fn [x] (gen/fmap #(str x (format "%03d" %)) (gen/choose 0 999))))
-      (gen/bind (fn [x] (gen/fmap #(str x %) char-uppercase-alphabetic)))))
+  (gen/fmap (fn [[year letter1 num letter2]]
+              (str "BC" year letter1 (format "%03d" num) letter2))
+            (gen/tuple two-digit-year
+                       char-uppercase-alphabetic
+                       (gen/choose 0 999)
+                       char-uppercase-alphabetic)))
 
 
 (def container-id
-  (-> (gen/return "R")
-      (gen/bind (fn [x] (gen/fmap #(str x (format "%010d" %)) (gen/choose 0 9999999999))))))
+  (gen/fmap #(str "R" (format "%010d" %)) (gen/choose 0 9999999999)))
 
 
 (comment

--- a/test/run_simulator/generators_test.clj
+++ b/test/run_simulator/generators_test.clj
@@ -1,0 +1,30 @@
+(ns run-simulator.generators-test
+  (:require [clojure.test :as t]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [run-simulator.generators :as generators]))
+
+
+(t/deftest miseq-run-id-matches-regex
+  (t/testing "Generated MiSeq run IDs match expected pattern"
+    (doseq [id (gen/sample generators/miseq-run-id 20)]
+      (t/is (re-matches generators/miseq-run-id-regex id) (str "Failed for: " id)))))
+
+
+(t/deftest nextseq-run-id-matches-regex
+  (t/testing "Generated NextSeq run IDs match expected pattern"
+    (doseq [id (gen/sample generators/nextseq-run-id 20)]
+      (t/is (re-matches generators/nextseq-run-id-regex id) (str "Failed for: " id)))))
+
+
+(t/deftest i100-run-id-matches-regex
+  (t/testing "Generated i100 run IDs match expected pattern"
+    (doseq [id (gen/sample generators/i100-run-id 20)]
+      (t/is (re-matches generators/i100-run-id-regex id) (str "Failed for: " id)))))
+
+
+(t/deftest specs-have-generators
+  (t/testing "Specs can produce values via s/gen"
+    (t/is (s/valid? ::generators/miseq-run-id (gen/generate (s/gen ::generators/miseq-run-id))))
+    (t/is (s/valid? ::generators/nextseq-run-id (gen/generate (s/gen ::generators/nextseq-run-id))))
+    (t/is (s/valid? ::generators/i100-run-id (gen/generate (s/gen ::generators/i100-run-id))))))


### PR DESCRIPTION
- Replace gen/such-that rejection sampling with gen/elements for
  character generators (faster, can't fail)
- Replace gen/bind chains with gen/tuple + gen/fmap for compound
  generators (clearer, independent shrinking)
- Link specs to generators via s/with-gen so s/gen works
- Replace (first (spec-gen/sample gen 1)) with gen/generate in core.clj
- Fix i100 run number to use zero-padded format matching its regex
- Fix timestamp ranges (hours 0-23, minutes/seconds 0-59)
- Simplify zero-padded-month to reuse make-zero-padded-num
- Add generator tests validating output against regex specs

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PKVo7yP7hcNM8PUD1Bw8sm