### PR TITLE
Add tile-level cluster generation and BCL/LOCS/filter file writing

### DIFF
--- a/src/run_simulator/bcl.clj
+++ b/src/run_simulator/bcl.clj
@@ -1,6 +1,6 @@
 (ns run-simulator.bcl
-  (:require [run-simulator.util :as util])
-  (:import java.nio.ByteBuffer))
+  (:require [clojure.java.io :as io]
+            [run-simulator.util :as util]))
 
 (def bcl-header-size 4)
 
@@ -36,12 +36,51 @@
   "Read the cluster count from the 4-byte BCL file header (little-endian)."
   [bcl-bytes]
   (let [num-clusters-bytes (take 4 bcl-bytes)]
-    (util/bytes->long (byte-array num-clusters-bytes) :little-endian)))
+    (util/bytes->int (byte-array num-clusters-bytes) :little-endian)))
 
-(comment
-    (def test-bcl-path "test/resources/picard_bcl_passing.bcl")
-    (def test-bcl-bytes (util/slurp-bytes test-bcl-path))
-    (def num-test-bcl-clusters (num-clusters test-bcl-bytes))
-    (last (map byte->basecall (drop bcl-header-size test-bcl-bytes)))
-    
-  )
+(def ^:private base->bits
+  {\A 0 \C 1 \G 2 \T 3})
+
+
+(defn encode-bcl-byte
+  "Encode a base character and quality score into a single BCL byte."
+  [base qual]
+  (if (= \N base)
+    (unchecked-byte 0)
+    (unchecked-byte (bit-or (bit-shift-left (min qual 63) 2)
+                            (base->bits base)))))
+
+
+(defn write-bcl-file!
+  "Write one BCL file for a single cycle. clusters is a seq of cluster maps,
+   read-key is :r1-bases or :r2-bases, qual-key is :r1-quals or :r2-quals,
+   cycle-index is the 0-based position within that read."
+  [path clusters read-key qual-key cycle-index]
+  (let [n (count clusters)
+        header (util/int->bytes n :little-endian)
+        data (byte-array (map (fn [cluster]
+                                (let [base (nth (read-key cluster) cycle-index)
+                                      qual (nth (qual-key cluster) cycle-index)]
+                                  (encode-bcl-byte base qual)))
+                              clusters))]
+    (io/make-parents path)
+    (with-open [out (io/output-stream (io/file path))]
+      (.write out ^bytes header)
+      (.write out ^bytes data))))
+
+
+(defn write-tile-bcl-files!
+  "Write all BCL files for a tile: one file per cycle for R1 and R2."
+  [base-dir lane tile clusters read-length]
+  (let [lane-str (format "L%03d" lane)
+        tile-str (str tile)]
+    (dotimes [i read-length]
+      (let [cycle-num (inc i)
+            cycle-dir (format "C%d.1" cycle-num)
+            path (io/file base-dir lane-str cycle-dir (str "s_" lane "_" tile-str ".bcl"))]
+        (write-bcl-file! path clusters :r1-bases :r1-quals i)))
+    (dotimes [i read-length]
+      (let [cycle-num (+ read-length (inc i))
+            cycle-dir (format "C%d.1" cycle-num)
+            path (io/file base-dir lane-str cycle-dir (str "s_" lane "_" tile-str ".bcl"))]
+        (write-bcl-file! path clusters :r2-bases :r2-quals i)))))

--- a/src/run_simulator/core.clj
+++ b/src/run_simulator/core.clj
@@ -4,13 +4,19 @@
             [clojure.tools.cli :refer [parse-opts]]
             [clojure.spec.alpha :as spec]
             [clojure.spec.gen.alpha :as gen]
+            [clojure.data.xml :as xml]
             [taoensso.telemere :as tel]
             [run-simulator.cli :as cli]
             [run-simulator.util :as util]
             [run-simulator.generators :as generators]
             [run-simulator.samplesheet :as samplesheet]
             [run-simulator.reference :as reference]
-            [run-simulator.fastq :as fastq])
+            [run-simulator.fastq :as fastq]
+            [run-simulator.tile :as tile]
+            [run-simulator.bcl :as bcl]
+            [run-simulator.locs :as locs]
+            [run-simulator.filter :as filt]
+            [run-simulator.runinfo :as runinfo])
   (:gen-class))
 
 
@@ -185,6 +191,9 @@
      :samplesheet-string samplesheet-string
      :samplesheet-files samplesheet-files
      :fastq-subdir fastq-subdir
+     :bcl-base-dir (io/file run-output-dir "Data" "Intensities" "BaseCalls")
+     :locs-base-dir (io/file run-output-dir "Data" "Intensities")
+     :tiles [1101]
      :fastq-params {:read-length read-length
                     :instrument instrument-id
                     :run-number padded-run-num
@@ -197,12 +206,30 @@
      :mark-qc-check-complete (:mark-qc-check-complete config)}))
 
 
+(defn write-runinfo-xml!
+  "Write RunInfo.xml for the run."
+  [{:keys [run-id run-output-dir instrument-type fastq-params]}]
+  (let [read-length (:read-length fastq-params)
+        runinfo-data (case instrument-type
+                       :miseq (runinfo/generate-runinfo-data-miseq run-id read-length)
+                       :nextseq (runinfo/generate-runinfo-data-nextseq run-id read-length)
+                       :i100 (runinfo/generate-runinfo-data-nextseq run-id read-length))
+        xml-str (xml/indent-str (xml/sexp-as-element runinfo-data))
+        path (io/file run-output-dir "RunInfo.xml")]
+    (spit path xml-str)
+    (tel/log! {:level :info :id :run/created-runinfo-xml
+               :data {:run-id run-id :path (str path)}})))
+
+
 (defn write-run!
-  "Write all run output: directories, samplesheets, FASTQ files, and optional completion markers."
+  "Write all run output: directories, samplesheets, BCL, LOCS, filter, FASTQ files, and optional completion markers."
   [{:keys [run-id run-output-dir samples num-samples
            samplesheet-string samplesheet-files
            fastq-subdir fastq-params reference-seqs
-           mark-upload-complete mark-qc-check-complete]}]
+           bcl-base-dir locs-base-dir tiles
+           instrument-type
+           mark-upload-complete mark-qc-check-complete]
+    :as plan}]
   (.mkdirs run-output-dir)
   (tel/log! {:level :info :id :run/created-output-dir
              :data {:run-id run-id :run-output-dir (str run-output-dir)}})
@@ -217,20 +244,44 @@
       (tel/log! {:level :info :id :run/created-samplesheet-file
                  :data {:run-id run-id :samplesheet-file (str samplesheet-file)}})))
 
+  (write-runinfo-xml! plan)
+
   (.mkdirs fastq-subdir)
   (tel/log! {:level :info :id :run/created-fastq-subdir
              :data {:run-id run-id :fastq-subdir (str fastq-subdir)}})
 
-  (doseq [[sample-num sample] (map-indexed vector samples)]
-    (let [primary-species (:_primary-species sample)
-          primary-ref (get reference-seqs primary-species)
-          contaminant-refs (dissoc (select-keys reference-seqs (keys (:_species-weights sample))) primary-species)
-          cross-contamination-rate (:_cross-contamination-rate sample 0)]
-      (fastq/write-sample-fastqs! fastq-subdir sample-num sample
-                                  (assoc fastq-params
-                                         :primary-reference-seq primary-ref
-                                         :contaminant-reference-seqs contaminant-refs
-                                         :cross-contamination-rate cross-contamination-rate))))
+  (let [lane (:lane fastq-params)
+        read-length (:read-length fastq-params)
+        header-params (select-keys fastq-params [:instrument :run-number :flowcell-id :lane :tile])]
+    (doseq [tile-id tiles]
+      (let [clusters (tile/generate-tile-clusters
+                      {:samples samples
+                       :fastq-params fastq-params
+                       :reference-seqs reference-seqs})
+            clusters-by-sample (group-by :sample-index clusters)]
+
+        (locs/write-locs-file!
+         (io/file locs-base-dir (str "s_" lane "_" tile-id ".locs"))
+         clusters)
+        (tel/log! {:level :info :id :run/created-locs-file
+                   :data {:run-id run-id :tile tile-id :num-clusters (count clusters)}})
+
+        (filt/write-filter-file!
+         (io/file bcl-base-dir (format "L%03d" lane) (str "s_" lane "_" tile-id ".filter"))
+         clusters)
+        (tel/log! {:level :info :id :run/created-filter-file
+                   :data {:run-id run-id :tile tile-id}})
+
+        (bcl/write-tile-bcl-files! bcl-base-dir lane tile-id clusters read-length)
+        (tel/log! {:level :info :id :run/created-bcl-files
+                   :data {:run-id run-id :tile tile-id :num-cycles (* 2 read-length)}})
+
+        (doseq [[sample-index sample-clusters] (sort-by key clusters-by-sample)]
+          (let [sample (nth samples sample-index)
+                sample-id (:Sample_ID sample)]
+            (fastq/write-sample-fastqs-from-clusters!
+             fastq-subdir sample-index sample-id sample-clusters
+             (assoc header-params :tile tile-id)))))))
 
   (tel/log! {:level :info :id :run/created-fastq-files
              :data {:run-id run-id :fastq-subdir (str fastq-subdir) :num-fastq-files (* num-samples 2)}})

--- a/src/run_simulator/fastq.clj
+++ b/src/run_simulator/fastq.clj
@@ -62,7 +62,7 @@
                  r2-seq r2-qual-str)}))
 
 
-(defn- select-reference-seq
+(defn select-reference-seq
   "Select a reference sequence for one read. With probability (1 - cross-contamination-rate),
    returns the primary; otherwise picks uniformly from contaminants."
   [primary-reference-seq contaminant-reference-seqs cross-contamination-rate]
@@ -118,6 +118,36 @@
                        (or (:index2 sample) (:Index2 sample) ""))
         {:keys [r1-content r2-content]}
         (generate-sample-fastq (assoc fastq-params :index-sequence index-seq))
+        r1-path (io/file fastq-subdir (str sample-id "_S" sample-num "_L001_R1_001.fastq.gz"))
+        r2-path (io/file fastq-subdir (str sample-id "_S" sample-num "_L001_R2_001.fastq.gz"))]
+    (write-fastq-gz! r1-path r1-content)
+    (write-fastq-gz! r2-path r2-content)))
+
+
+(defn cluster->fastq-records
+  "Convert a cluster record to formatted R1 and R2 FASTQ record strings."
+  [cluster {:keys [instrument run-number flowcell-id lane tile]}]
+  (let [r1-qual-str (seq/quality-scores->string (:r1-quals cluster))
+        r2-qual-str (seq/quality-scores->string (:r2-quals cluster))
+        base-header {:instrument instrument :run-number run-number
+                     :flowcell-id flowcell-id :lane lane :tile tile
+                     :x-pos (:x-pos cluster) :y-pos (:y-pos cluster)
+                     :is-filtered "N" :control-number 0
+                     :index-sequence (:index-sequence cluster)}]
+    {:r1-record (format-fastq-record
+                 (format-fastq-header (assoc base-header :read 1))
+                 (:r1-bases cluster) r1-qual-str)
+     :r2-record (format-fastq-record
+                 (format-fastq-header (assoc base-header :read 2))
+                 (:r2-bases cluster) r2-qual-str)}))
+
+
+(defn write-sample-fastqs-from-clusters!
+  "Write gzipped R1 and R2 FASTQ files for a sample from pre-generated cluster records."
+  [fastq-subdir sample-num sample-id clusters header-params]
+  (let [records (map #(cluster->fastq-records % header-params) clusters)
+        r1-content (str (str/join "\n" (map :r1-record records)) "\n")
+        r2-content (str (str/join "\n" (map :r2-record records)) "\n")
         r1-path (io/file fastq-subdir (str sample-id "_S" sample-num "_L001_R1_001.fastq.gz"))
         r2-path (io/file fastq-subdir (str sample-id "_S" sample-num "_L001_R2_001.fastq.gz"))]
     (write-fastq-gz! r1-path r1-content)

--- a/src/run_simulator/filter.clj
+++ b/src/run_simulator/filter.clj
@@ -1,0 +1,26 @@
+(ns run-simulator.filter
+  (:require [clojure.java.io :as io]
+            [run-simulator.util :as util]))
+
+
+(def filter-version 3)
+
+
+(defn write-filter-file!
+  "Write a .filter file for a tile. clusters is a seq of maps with :passed-filter."
+  [path clusters]
+  (let [n (count clusters)
+        zero-bytes (util/int->bytes 0 :little-endian)
+        version-bytes (util/int->bytes filter-version :little-endian)
+        count-bytes (util/int->bytes n :little-endian)
+        data (byte-array (map (fn [cluster]
+                                (if (:passed-filter cluster)
+                                  (unchecked-byte 1)
+                                  (unchecked-byte 0)))
+                              clusters))]
+    (io/make-parents path)
+    (with-open [out (io/output-stream (io/file path))]
+      (.write out ^bytes zero-bytes)
+      (.write out ^bytes version-bytes)
+      (.write out ^bytes count-bytes)
+      (.write out ^bytes data))))

--- a/src/run_simulator/locs.clj
+++ b/src/run_simulator/locs.clj
@@ -25,7 +25,7 @@
   [locs-bytes]
   (let [locs-header (take locs-header-size locs-bytes)
         num-clusters-bytes (byte-array (drop 8 locs-header))]
-    (util/bytes->long num-clusters-bytes :little-endian)))
+    (util/bytes->int num-clusters-bytes :little-endian)))
 
 
 (defn byteseq->coord 
@@ -72,19 +72,17 @@
      :y-qseq  y-qseq}))
  
 
-(comment
-
-  (def test-locs-path "test/resources/picard_s_1_6.locs")
-  (def test-locs-bytes (util/slurp-bytes test-locs-path))
-  (num-clusters test-locs-bytes)
-  (def first-coord (byteseq->coord (take 8 (drop 12 test-locs-bytes))))
-  (coord->byteseq first-coord)
-  (count (partition 8 (drop 12 test-locs-bytes)))
-
-  (with-open [out-file (io/output-stream (io/file "test_out.locs") :append true)]
-    (.write out-file (byte-array (coord->byteseq first-coord)) ))
-  (with-open [out-file (io/output-stream (io/file "test_out.locs") :append true)]
-    (.write out-file (byte-array (coord->byteseq first-coord)) ))
-  
-  
-  )
+(defn write-locs-file!
+  "Write a .locs file for a tile. clusters is a seq of maps with :x-float and :y-float."
+  [path clusters]
+  (let [n (count clusters)
+        magic-bytes (util/int->bytes locs-magic-num :little-endian)
+        version-bytes (util/float->bytes (float locs-version-num) :little-endian)
+        count-bytes (util/int->bytes n :little-endian)]
+    (io/make-parents path)
+    (with-open [out (io/output-stream (io/file path))]
+      (.write out ^bytes magic-bytes)
+      (.write out ^bytes version-bytes)
+      (.write out ^bytes count-bytes)
+      (doseq [cluster clusters]
+        (.write out (byte-array (coord->byteseq cluster)))))))

--- a/src/run_simulator/tile.clj
+++ b/src/run_simulator/tile.clj
@@ -1,0 +1,79 @@
+(ns run-simulator.tile
+  (:require [run-simulator.sequence :as seq]
+            [run-simulator.locs :as locs]
+            [run-simulator.fastq :as fastq]))
+
+
+(defn generate-cluster-coords
+  "Generate float and QSEQ integer coordinates for a cluster."
+  []
+  (let [{:keys [x-float y-float x-qseq y-qseq]}
+        (locs/random-coord {:min-x 0 :min-y 0 :max-x 2500 :max-y 2500})]
+    {:x-float x-float
+     :y-float y-float
+     :x-pos x-qseq
+     :y-pos y-qseq}))
+
+
+(defn generate-cluster
+  "Generate a single cluster record with sequences, qualities, coordinates, and metadata."
+  [{:keys [cluster-index sample-index sample-id index-sequence
+           reference-seq read-length error-profile]}]
+  (let [coords (generate-cluster-coords)
+        use-random (nil? reference-seq)
+        fragment-length (if use-random
+                          (* 2 read-length)
+                          (min (* 2 read-length) (count reference-seq)))
+        effective-read-length (if use-random
+                                read-length
+                                (min read-length (quot fragment-length 2)))
+        {:keys [r1 r2]} (if use-random
+                           {:r1 (seq/random-seq effective-read-length)
+                            :r2 (seq/random-seq effective-read-length)}
+                           (let [{:keys [subseq]} (seq/random-subseq reference-seq fragment-length)]
+                             (seq/reads-from-seq subseq effective-read-length)))
+        r1-quals (seq/generate-quality-scores effective-read-length error-profile)
+        r2-quals (seq/generate-quality-scores effective-read-length error-profile)
+        r1-bases (seq/introduce-errors r1 r1-quals)
+        r2-bases (seq/introduce-errors r2 r2-quals)]
+    (merge coords
+           {:cluster-index cluster-index
+            :sample-index sample-index
+            :sample-id sample-id
+            :index-sequence index-sequence
+            :r1-bases r1-bases
+            :r1-quals r1-quals
+            :r2-bases r2-bases
+            :r2-quals r2-quals
+            :passed-filter true})))
+
+
+(defn generate-tile-clusters
+  "Generate all clusters for a tile across all samples."
+  [{:keys [samples fastq-params reference-seqs]}]
+  (let [{:keys [read-length error-profile num-reads]} fastq-params]
+    (into []
+          (mapcat
+           (fn [[sample-index sample]]
+             (let [sample-id (:Sample_ID sample)
+                   index-seq (str (or (:index sample) (:Index sample) "")
+                                  "+"
+                                  (or (:index2 sample) (:Index2 sample) ""))
+                   primary-species (:_primary-species sample)
+                   primary-ref (get reference-seqs primary-species)
+                   contaminant-refs (dissoc (select-keys reference-seqs (keys (:_species-weights sample))) primary-species)
+                   cross-contamination-rate (:_cross-contamination-rate sample 0)]
+               (mapv (fn [read-index]
+                       (let [ref-seq (fastq/select-reference-seq
+                                      primary-ref contaminant-refs
+                                      (or cross-contamination-rate 0))]
+                         (generate-cluster
+                          {:cluster-index (+ (* sample-index num-reads) read-index)
+                           :sample-index sample-index
+                           :sample-id sample-id
+                           :index-sequence index-seq
+                           :reference-seq ref-seq
+                           :read-length read-length
+                           :error-profile error-profile})))
+                     (range num-reads)))))
+          (map-indexed vector samples))))

--- a/src/run_simulator/util.clj
+++ b/src/run_simulator/util.clj
@@ -141,6 +141,31 @@
   (+ a (* (- b a) (rand))))
 
 
+(defn bytes->int
+  "Convert a 4-byte array to an int. Endianness defaults to big-endian; pass :little-endian to override."
+  [bs & [endianness]]
+  {:pre [(bytes? bs)]}
+  (let [endianness (if (= endianness :little-endian)
+                     java.nio.ByteOrder/LITTLE_ENDIAN
+                     java.nio.ByteOrder/BIG_ENDIAN)]
+    (-> bs
+        (ByteBuffer/wrap)
+        (.order endianness)
+        .getInt)))
+
+
+(defn int->bytes
+  "Convert an int to a 4-byte array. Endianness defaults to big-endian; pass :little-endian to override."
+  [n & [endianness]]
+  (let [buf (ByteBuffer/allocate 4)
+        endianness (if (= endianness :little-endian)
+                     java.nio.ByteOrder/LITTLE_ENDIAN
+                     java.nio.ByteOrder/BIG_ENDIAN)]
+    (.order buf endianness)
+    (.putInt buf (int n))
+    (.array buf)))
+
+
 (defn bytes->long
   "Convert a byte array to a long. Endianness defaults to big-endian; pass :little-endian to override."
   [bs & [endianness]]

--- a/test/run_simulator/bcl_test.clj
+++ b/test/run_simulator/bcl_test.clj
@@ -1,5 +1,6 @@
 (ns run-simulator.bcl-test
   (:require [clojure.test :as t]
+            [clojure.java.io :as io]
             [run-simulator.bcl :as bcl]
             [run-simulator.util :as util]))
 
@@ -45,6 +46,45 @@
       (t/is (= 10 (:qual-int result))))))
 
 
-;; bcl/num-clusters and locs/num-clusters pass 4 bytes to bytes->long
-;; which expects 8 — a latent bug to fix separately.
+(t/deftest num-clusters-unit
+  (t/testing "Reads cluster count from picard test BCL file"
+    (let [bcl-bytes (util/slurp-bytes "test/resources/picard_bcl_passing.bcl")]
+      (t/is (pos? (bcl/num-clusters bcl-bytes))))))
 
+
+(t/deftest encode-bcl-byte-unit
+  (t/testing "Roundtrip: encode then decode recovers base and quality"
+    (doseq [base [\A \C \G \T]
+            qual [2 10 30 41 63]]
+      (let [encoded (bcl/encode-bcl-byte base qual)
+            decoded (bcl/byte->basecall encoded)]
+        (t/is (= base (:base decoded)))
+        (t/is (= qual (:qual-int decoded))))))
+  (t/testing "A with quality 0 produces null byte (no-call sentinel)"
+    (t/is (= 0 (Byte/toUnsignedInt (bcl/encode-bcl-byte \A 0)))))
+  (t/testing "N base encodes as null byte"
+    (t/is (= 0 (Byte/toUnsignedInt (bcl/encode-bcl-byte \N 30))))))
+
+
+(t/deftest write-bcl-file-unit
+  (t/testing "Written BCL file has correct header and data"
+    (let [clusters [{:r1-bases "ACG" :r1-quals [30 20 10]
+                     :r2-bases "TGA" :r2-quals [25 15 5]}
+                    {:r1-bases "TTT" :r1-quals [40 35 30]
+                     :r2-bases "AAA" :r2-quals [38 33 28]}]
+          tmp-file (io/file "test_output" "bcl_write_test" "test.bcl")]
+      (try
+        (bcl/write-bcl-file! tmp-file clusters :r1-bases :r1-quals 0)
+        (let [bytes (util/slurp-bytes (str tmp-file))
+              n (bcl/num-clusters bytes)
+              data-bytes (drop 4 bytes)]
+          (t/is (= 2 n))
+          (t/is (= \A (:base (bcl/byte->basecall (first data-bytes)))))
+          (t/is (= 30 (:qual-int (bcl/byte->basecall (first data-bytes)))))
+          (t/is (= \T (:base (bcl/byte->basecall (second data-bytes)))))
+          (t/is (= 40 (:qual-int (bcl/byte->basecall (second data-bytes))))))
+        (finally
+          (io/delete-file tmp-file true)
+          (doseq [d [(io/file "test_output" "bcl_write_test")
+                     (io/file "test_output")]]
+            (.delete d)))))))

--- a/test/run_simulator/filter_test.clj
+++ b/test/run_simulator/filter_test.clj
@@ -1,0 +1,29 @@
+(ns run-simulator.filter-test
+  (:require [clojure.test :as t]
+            [clojure.java.io :as io]
+            [run-simulator.filter :as filt]
+            [run-simulator.util :as util]))
+
+
+(t/deftest write-filter-file-unit
+  (t/testing "Written filter file has correct header and data"
+    (let [clusters [{:passed-filter true}
+                    {:passed-filter false}
+                    {:passed-filter true}]
+          tmp-file (io/file "test_output" "filter_write_test" "test.filter")]
+      (try
+        (filt/write-filter-file! tmp-file clusters)
+        (let [bytes (vec (util/slurp-bytes (str tmp-file)))
+              header-zeros (util/bytes->int (byte-array (take 4 bytes)) :little-endian)
+              version (util/bytes->int (byte-array (subvec bytes 4 8)) :little-endian)
+              n (util/bytes->int (byte-array (subvec bytes 8 12)) :little-endian)
+              data (subvec bytes 12)]
+          (t/is (= 0 header-zeros))
+          (t/is (= 3 version))
+          (t/is (= 3 n))
+          (t/is (= [1 0 1] (mapv #(Byte/toUnsignedInt %) data))))
+        (finally
+          (io/delete-file tmp-file true)
+          (doseq [d [(io/file "test_output" "filter_write_test")
+                     (io/file "test_output")]]
+            (.delete d)))))))

--- a/test/run_simulator/locs_test.clj
+++ b/test/run_simulator/locs_test.clj
@@ -1,6 +1,7 @@
 (ns run-simulator.locs-test
   (:require [clojure.java.io :as io]
             [run-simulator.locs :as locs]
+            [run-simulator.util :as util]
             [run-simulator.generators :as run-sim-gen]
             [clojure.test :as t]
             [clojure.test.check :as tc]
@@ -28,7 +29,32 @@
                        (>= max-y (:y-float coord))))))
 
 
-(comment
-  (gen/sample (gen/let [min-y gen/nat]
-                (gen/such-that #(> % min-y) (gen/scale #(* % 10) gen/nat))))
-  )
+(t/deftest num-clusters-unit
+  (t/testing "Reads cluster count from picard test LOCS file"
+    (let [locs-bytes (util/slurp-bytes "test/resources/picard_s_1_6.locs")]
+      (t/is (pos? (locs/num-clusters locs-bytes))))))
+
+
+(t/deftest write-locs-file-roundtrip
+  (t/testing "Written LOCS file can be read back with correct cluster count and coordinates"
+    (let [clusters [{:x-float 12.5 :y-float 34.7}
+                    {:x-float 100.0 :y-float 200.0}
+                    {:x-float 0.0 :y-float 0.0}]
+          tmp-file (io/file "test_output" "locs_write_test" "test.locs")]
+      (try
+        (locs/write-locs-file! tmp-file clusters)
+        (let [bytes (util/slurp-bytes (str tmp-file))
+              n (locs/num-clusters bytes)
+              coord-bytes (drop locs/locs-header-size bytes)
+              coords (map locs/byteseq->coord (partition 8 coord-bytes))]
+          (t/is (= 3 n))
+          (t/is (= 3 (count coords)))
+          (t/is (< (Math/abs (- 12.5 (:x-float (first coords)))) 0.01))
+          (t/is (< (Math/abs (- 34.7 (:y-float (first coords)))) 0.01))
+          (t/is (< (Math/abs (- 100.0 (:x-float (second coords)))) 0.01))
+          (t/is (< (Math/abs (- 200.0 (:y-float (second coords)))) 0.01)))
+        (finally
+          (io/delete-file tmp-file true)
+          (doseq [d [(io/file "test_output" "locs_write_test")
+                     (io/file "test_output")]]
+            (.delete d)))))))

--- a/test/run_simulator/tile_test.clj
+++ b/test/run_simulator/tile_test.clj
@@ -1,0 +1,69 @@
+(ns run-simulator.tile-test
+  (:require [clojure.test :as t]
+            [run-simulator.tile :as tile]))
+
+
+(t/deftest generate-cluster-coords-unit
+  (t/testing "Returns both float and integer coordinates"
+    (let [coords (tile/generate-cluster-coords)]
+      (t/is (contains? coords :x-float))
+      (t/is (contains? coords :y-float))
+      (t/is (contains? coords :x-pos))
+      (t/is (contains? coords :y-pos))
+      (t/is (number? (:x-float coords)))
+      (t/is (number? (:y-float coords)))
+      (t/is (integer? (:x-pos coords)))
+      (t/is (integer? (:y-pos coords))))))
+
+
+(t/deftest generate-cluster-unit
+  (t/testing "Returns cluster with all expected keys"
+    (let [ref-seq (apply str (repeat 100 "ACGT"))
+          cluster (tile/generate-cluster
+                   {:cluster-index 0
+                    :sample-index 0
+                    :sample-id "test-sample"
+                    :index-sequence "ACGT+TGCA"
+                    :reference-seq ref-seq
+                    :read-length 50
+                    :error-profile {:L 0.1 :k 0.05 :x0 200}})]
+      (t/is (= 0 (:cluster-index cluster)))
+      (t/is (= "test-sample" (:sample-id cluster)))
+      (t/is (= 50 (count (:r1-bases cluster))))
+      (t/is (= 50 (count (:r2-bases cluster))))
+      (t/is (= 50 (count (:r1-quals cluster))))
+      (t/is (= 50 (count (:r2-quals cluster))))
+      (t/is (true? (:passed-filter cluster)))))
+  (t/testing "Works with nil reference (random sequence)"
+    (let [cluster (tile/generate-cluster
+                   {:cluster-index 0
+                    :sample-index 0
+                    :sample-id "test-sample"
+                    :index-sequence "ACGT+TGCA"
+                    :reference-seq nil
+                    :read-length 50
+                    :error-profile {:L 0.1 :k 0.05 :x0 200}})]
+      (t/is (= 50 (count (:r1-bases cluster))))
+      (t/is (= 50 (count (:r2-bases cluster)))))))
+
+
+(t/deftest generate-tile-clusters-unit
+  (t/testing "Generates correct number of clusters across samples"
+    (let [samples [{:Sample_ID "sample-1" :Index "ACGT" :Index2 "TGCA"
+                    :_primary-species "SARS-CoV-2"
+                    :_species-weights {"SARS-CoV-2" 1.0}
+                    :_cross-contamination-rate 0}
+                   {:Sample_ID "sample-2" :Index "GGGG" :Index2 "CCCC"
+                    :_primary-species "SARS-CoV-2"
+                    :_species-weights {"SARS-CoV-2" 1.0}
+                    :_cross-contamination-rate 0}]
+          ref-seq (apply str (repeat 100 "ACGT"))
+          clusters (tile/generate-tile-clusters
+                    {:samples samples
+                     :fastq-params {:read-length 50
+                                    :error-profile {:L 0.1 :k 0.05 :x0 200}
+                                    :num-reads 5}
+                     :reference-seqs {"SARS-CoV-2" ref-seq}})]
+      (t/is (= 10 (count clusters)))
+      (t/is (= 5 (count (filter #(= 0 (:sample-index %)) clusters))))
+      (t/is (= 5 (count (filter #(= 1 (:sample-index %)) clusters)))))))


### PR DESCRIPTION
## Summary
This PR refactors the run simulation pipeline to generate clusters at the tile level and write Illumina binary output formats (BCL, LOCS, filter files) before generating FASTQ files. This enables more realistic simulation of the sequencer's actual output hierarchy and supports downstream tools that expect these intermediate formats.

## Key Changes

- **New tile module** (`src/run_simulator/tile.clj`): Generates cluster records with sequences, qualities, and coordinates for all samples within a tile
  - `generate-cluster-coords`: Creates both float and QSEQ integer coordinates for clusters
  - `generate-cluster`: Produces individual cluster records with R1/R2 bases, qualities, and metadata
  - `generate-tile-clusters`: Generates all clusters for a tile across all samples

- **BCL file writing** (`src/run_simulator/bcl.clj`):
  - Added `encode-bcl-byte`: Encodes base and quality into single BCL byte format
  - Added `write-bcl-file!`: Writes one BCL file per cycle
  - Added `write-tile-bcl-files!`: Generates all BCL files for a tile (R1 and R2 cycles)
  - Fixed `num-clusters` to use `bytes->int` instead of `bytes->long` (4-byte header)

- **LOCS file writing** (`src/run_simulator/locs.clj`):
  - Added `write-locs-file!`: Writes cluster coordinate file with magic number, version, and float coordinates

- **Filter file writing** (`src/run_simulator/filter.clj`): New module
  - Added `write-filter-file!`: Writes filter file indicating which clusters passed QC

- **FASTQ refactoring** (`src/run_simulator/fastq.clj`):
  - Made `select-reference-seq` public (was private)
  - Added `cluster->fastq-records`: Converts cluster records to FASTQ format
  - Added `write-sample-fastqs-from-clusters!`: Writes FASTQ files from pre-generated clusters

- **Core pipeline update** (`src/run_simulator/core.clj`):
  - Added `write-runinfo-xml!`: Generates RunInfo.xml for the run
  - Refactored `write-run!` to generate clusters per tile, then write BCL/LOCS/filter files before FASTQ
  - Added tile-level processing with proper directory structure

- **Utility functions** (`src/run_simulator/util.clj`):
  - Added `bytes->int`: Converts 4-byte arrays to integers (little/big-endian)
  - Added `int->bytes`: Converts integers to 4-byte arrays (little/big-endian)

- **Comprehensive test coverage**:
  - New `tile_test.clj`: Tests cluster generation and coordinate handling
  - New `filter_test.clj`: Tests filter file writing
  - Updated `bcl_test.clj`: Added roundtrip encoding tests and file writing tests
  - Updated `locs_test.clj`: Added file writing roundtrip tests

## Notable Implementation Details

- Clusters are now generated once per tile and reused for all output formats, improving efficiency
- BCL encoding uses 2-bit base + 6-bit quality format per byte
- LOCS files store float coordinates with magic number (0x00000000) and version (1.0) headers
- Filter files use version 3 format with 1 byte per cluster (1 = pass, 0 = fail)
- FASTQ headers are now constructed from cluster metadata including tile, X/Y positions, and index sequences
- Proper directory structure created for lane/cycle organization in BaseCalls directory

https://claude.ai/code/session_01PKVo7yP7hcNM8PUD1Bw8sm